### PR TITLE
Change \n{3,} to \n\n everywhere.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# nfJson 
+# nfJson
 
 **Provides a set of fast performance, reliable and easy to use Json functions using pure VFP.**
 
@@ -16,17 +16,15 @@ Project Manager: Marco Plaza
 
 * cJsonString = **nfCursorToJson4vfp()**  _&& converts current open table/cursor to Json suitable for later use of nfJsonToCursor()_
 
-* cJsonString = **nfCursorToJson(**_lReturnArray, lArrayofValues, lIncludestruct, lFormattedOutput_**)**    converts current open table/cursor to Json 
+* cJsonString = **nfCursorToJson(**_lReturnArray, lArrayofValues, lIncludestruct, lFormattedOutput_**)**    converts current open table/cursor to Json
 
 * oJson = **nfCursorToObject(**_lCopyToArray, lIncludeStruct_**)**
 
-* cJsonString = **jsonFormat( cJsonStr )\*** Format json string w/o validate or change element positions  
- 
+* cJsonString = **jsonFormat( cJsonStr )\*** Format json string w/o validate or change element positions
 
 * **BETA PREVIEW: nfOpenJson(** cJsonString , [ cArrayPath ], [cCursorStructure & object mappings ] )
 
-	Similar to SqlServer 2016 openJson function. Allows you to convert Json to cursor. Pass jsonString , optional array path using  $. as object root and cursor structure as string with following structure for each column: `-<fieldName> <castExpression> [<$.propertyPath>]` Object types must use JSON as cast type ( see example ). Please check nfOpenJsonTest and [https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql](https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql) for clear understanding. 
-
+	Similar to SqlServer 2016 openJson function. Allows you to convert Json to cursor. Pass jsonString , optional array path using  $. as object root and cursor structure as string with following structure for each column: `-<fieldName> <castExpression> [<$.propertyPath>]` Object types must use JSON as cast type ( see example ). Please check nfOpenJsonTest and [https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql](https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql) for clear understanding.
 
 		 text to mssample2 noshow
 		[
@@ -54,8 +52,7 @@ Project Manager: Marco Plaza
 		  }
 		]
 		ENDTEXT
-		
-		
+
 		nfOpenJson( m.mssample2,'$.array', ' ;
 		 - Number    v(200) $.Order.Number  ;
 		 - Date      t      $.Order.Date    ;
@@ -64,15 +61,14 @@ Project Manager: Marco Plaza
 		 - itemQuantity i   $.Item.Quantity ;
 		 - Order  JSON ;
 		 ' )
-		
-		browse
-		
-		nfOpenJson( m.msSample2 )
-		browse
-		
-		nfOpenJson( m.msSample2,'$.array')
+
 		browse
 
+		nfOpenJson( m.msSample2 )
+		browse
+
+		nfOpenJson( m.msSample2,'$.array')
+		browse
 
 ## Tests & Sample files
 
@@ -100,74 +96,73 @@ Project Manager: Marco Plaza
 2019/06/14
 
 * JsonFormat function by Carlos Alloati
- 
+
 2017/08/05
 
 * no matter wich strictdate setting you have set, a JsonDateTime "0000-00-00T00:00:00" will return an empty date.
 * valid JsonDates with time "T00:00:00" will return a date value ( ie: {"testDate":"2017-12-01T00:00:00"} )
-* invalid dates ( ie 2017/50/50 ) properly formatted as Json Date ( ie: 2017-50-50T00:00:00 ) will throw error; 
+* invalid dates ( ie 2017/50/50 ) properly formatted as Json Date ( ie: 2017-50-50T00:00:00 ) will throw error;
  ( previous behavior was to return .null. )
 
-
-2017/03/10  
+2017/03/10
 
 * fixed: proper support for 19 character strings with ISO basic date format & different strictdate settings.
 
-2017/02/05  
+2017/02/05
 
 * fixed: nfJsonRead bug fix: incorrect parsing for strings terminated with escaped double quotes; minor changes & code refactoring.
 
-2017/01/11  
+2017/01/11
 
 * fixed: nfJsonRead: incorrect unescaped output with "set exact = on"
 * escapetest.prg - removed "leftover" lines.
 
-2017/01/11  
+2017/01/11
 
 * fixed issue escaping values terminated with "
 * nfJsonRead: removed parameter "isFile" now you can just pass a file name or string
 * added test: escapeTest.prg
 
-2016/09/28  
+2016/09/28
 
-* minor bug fix: zero item collections created as 1 empty item collection 
+* minor bug fix: zero item collections created as 1 empty item collection
 * proper indent for raw/formatted collection objects
 
-2016/08/16  
+2016/08/16
 
-* nfJsonPerfTest: added compiled exe, samples file ships as a separate file for you to edit 
-* fixed bug on test prgs: clean installs would fail due to missing temp folder on distribution zip w/o tests\temp folder 
+* nfJsonPerfTest: added compiled exe, samples file ships as a separate file for you to edit
+* fixed bug on test prgs: clean installs would fail due to missing temp folder on distribution zip w/o tests\temp folder
 * fixed bug on collectionTest
 
-2016/07/22  
+2016/07/22
 
 * nfJsonRead: Improved error management
 * CollectionTest: added new test
 
-2016/07/20  
+2016/07/20
 
 * Fixed bug: missing closing curly brace on collections as object member
 * Updated collections program test
 
-2016/07/09  
+2016/07/09
 
 * Automatic cast for datetime properties ( ISO-8601 basic format & vfp compilant as described on [https://en.wikipedia.org/wiki/ISO_8601#Times](https://en.wikipedia.org/wiki/ISO_8601#Times). )
 * nfJsonToCursor Bug Fix: "Date/datetime evaluated to an invalid value" while running under "strictdate = 1" converting empty dates back from Json
 
-2016/07/04  
+2016/07/04
 
 * Added support for control characters encoding ( chr( 0) ~ chr(31) )
 
-2016/05/05  
+2016/05/05
 
 * invalid Json error shows calling program information
 
-2016/04/02  
+2016/04/02
 
 * complex nested objects/arrays validation
 * missing object/array closures validation
 
-2016/03/28  
+2016/03/28
 
 * nfJsonRead performs JSON validation: invalid Json throws error indicating reason.
 * nfJsonPerfTest: proper error management enabled for invalid Json input from clipboard

--- a/nfJson/Tests/collectionTest.prg
+++ b/nfJson/Tests/collectionTest.prg
@@ -21,10 +21,7 @@ Catch
 
 Endtry
 
-
-
 Clear
-
 
 oparent = CREATEOBJECT('empty')
 
@@ -44,15 +41,14 @@ Set Path To ..\
 
 declare arrayTest(2)
 
-
 * test 1: object with collection and collection as array items
 arrayTest(1) = m.oParent
 arrayTest(2) = m.oCollection
-cJson1 = nfJsonCreate(@arrayTest,.T.,.T.) 
+cJson1 = nfJsonCreate(@arrayTest,.T.,.T.)
 
 * test 2
-* myforms is the name we want to assign to the root element ( the collection ) of resulting object 
-cJson2 = nfJsonCreate(oCollection,.T.,.T.,'myForms') 
+* myforms is the name we want to assign to the root element ( the collection ) of resulting object
+cJson2 = nfJsonCreate(oCollection,.T.,.T.,'myForms')
 
 Strtofile( m.cJson2 ,'temp\colltest.json')
 
@@ -61,13 +57,13 @@ Modify File temp\colltest.json
 && reset the variable, open debugger may not show object changes if you don't do so.
 
 oCollectionFromJson1 = ''
-oDebugCollection1 = '' 
+oDebugCollection1 = ''
 
 oCollectionFromJson1 = nfJsonRead(m.cJson1,.T.) && <- this will parse json and create a vfp collection
 oDebugCollection1 = nfJsonRead(m.cJson1) && <- this will parse object as it is represented in json
 
 oCollectionFromJson2 = ''
-oDebugCollection2 = '' 
+oDebugCollection2 = ''
 
 oCollectionFromJson2 = nfJsonRead(m.cJson2,.T.) && <- this will parse json and create a vfp collection
 oDebugCollection2 = nfJsonRead(m.cJson2) && <- this will parse object as it is represented in json
@@ -86,11 +82,9 @@ oDebugCollection2 = nfJsonRead(m.cJson2) && <- this will parse object as it is r
 * messagebox( [ oCollectionFromJson.array(2).Item(5).item(3).item(4).item('Product') = ]+ oCollectionFromJson.array(1).Item(5).item(3).item(4).item('Product'),0)
  messagebox( [ oCollectionFromJson1.array(1).collectiontest1.Item(5).item(3).item(4).item('Product') = ]+ oCollectionFromJson1.array(1).collectionTest1.Item(5).item(3).item(4).item('Product'),0)
  messagebox( [ oCollectionFromJson1.array(2).Item(5).item(3).item(4).item('Product') = ]+ oCollectionFromJson1.array(2).Item(5).item(3).item(4).item('Product'),0)
- 
+
 * test 2: ( using root name for collection object )
 messagebox( [ oCollectionFromJson2.myforms.Item(5).item(3).item(4).item('Product')  = ]+ oCollectionFromJson2.myforms.Item(5).item(3).item(4).item('Product'),0)
-
-
 
 *---------------------------------------
 FUNCTION addcollection( oo )
@@ -115,7 +109,7 @@ WITH m.oo
 			.Add("CCC") && item 2
 			.Add(Createobject("session")) && item 3
 			.Add(Createobject("Collection")) && item 4
-			
+
 			with .Item(4)
 				.Add('VFP','Product')
 				.Add(Program(),'Executing program Name')
@@ -128,5 +122,3 @@ WITH m.oo
 	Endwith
 
 Endwith
-
-

--- a/nfJson/Tests/emptyDateTest.PRG
+++ b/nfJson/Tests/emptyDateTest.PRG
@@ -1,7 +1,5 @@
 
 
-
-
 o = nfJsonRead('{"testDate":"2017-12-01T00:00:00"}')
 ? 'should be date:',vartype(o.testDate)
 
@@ -16,8 +14,6 @@ o = nfJsonRead('{"testDate":"2017-12-01T01:00:00"}')
 
 o = nfJsonRead('{"testDate":"0000-00-00T00:00:00"}')
 ? 'should be empty:',empty(o.testDate), vartype(o.testDate)
-
-
 
 create cursor test ( adatetime t null , adate d null )
 insert into test ( adatetime, adate ) values ( .null.,.null. )

--- a/nfJson/Tests/escapetest.PRG
+++ b/nfJson/Tests/escapetest.PRG
@@ -4,7 +4,7 @@ set path to ..\
 
 private all
 
-public pair 
+public pair
 
 pair = CREATEOBJECT("empty")
 
@@ -21,5 +21,3 @@ ee = nfJsonRead(m.json)
 
 ? ee.test
 ? pair.test
-
-

--- a/nfJson/Tests/examples.PRG
+++ b/nfJson/Tests/examples.PRG
@@ -21,10 +21,7 @@ Catch
 
 Endtry
 
-
-
 Clear
-
 
 *************************************************************************
 * will read and parse all json files found in jsonSamples\
@@ -33,7 +30,6 @@ Clear
 *************************************************************************
 
 Public myObjectFromJson
-
 
 myObjectFromJson = Createobject('empty')
 
@@ -54,7 +50,6 @@ For x = 1 To m.nFiles
 
 Endfor
 
-
 ******************************************************
 * create json String back from myObjectFromJson
 * raw / formatted
@@ -70,8 +65,6 @@ ENDIF
 Strtofile( m.jsonFormatted , 'temp\test_Formatted_'+Sys(2015)+'.Json' )
 Strtofile( m.jsonRaw , 'temp\test_Raw_'+Sys(2015)+'.Json' )
 
-
-
 Modify File temp\*.json Nowait
 
 =Sys(1500,"_MWI_CASCADE","_MSM_WINDO")
@@ -86,12 +79,10 @@ Store ''  To oFromRaw,oFromFormatted
 oFromRaw = nfJsonRead( m.jsonRaw )
 oFromFormatted = nfJsonRead( m.jsonFormatted )
 
-
 messagebox( 'Please inspect myObjectFromJson , oFromRaw, oFromFormatted in your debugger ',0)
 
-
 ***************************************************
-* convert cursor to Json using 
+* convert cursor to Json using
 * different output options:
 ***************************************************
 
@@ -99,7 +90,6 @@ Select Top 2 ;
 	employeeId,firstName,lastName,birthDate,city ;
 	from (Sys(2004)+'\samples\northwind\employees') ;
 	order By 1 Into Cursor temp
-
 
 TEXT to demoCursor textmerge
 
@@ -111,11 +101,9 @@ TEXT to demoCursor textmerge
 
  << nfCursorToJson(.t.) >>
 
-
 -Cursor as Object with array of objects ( default) :
 
 << nfCursorToJson() >>
-
 
 -Cursor as Object with array of values:
 
@@ -128,8 +116,7 @@ TEXT to demoCursor textmerge
 ENDTEXT
 
 Strtofile( demoCursor, 'temp\Cursor tests Output.txt')
-Modify File 'temp\Cursor tests Output.txt' nowait 
-
+Modify File 'temp\Cursor tests Output.txt' nowait
 
 ****************************************************************
 * create a cursor back from json:
@@ -143,7 +130,7 @@ Select * ;
 
 cJson = nfCursorToJson4vfp()
 
-close databases 
+close databases
 
 * create named cursor:
 
@@ -152,7 +139,6 @@ close databases
 go top
 browse nowait
 messagebox( 'Cursor back from Json!',64)
-
 
 * creates a temp cursor, return alias name:
 

--- a/nfJson/Tests/nfopenjsontest.PRG
+++ b/nfJson/Tests/nfopenjsontest.PRG
@@ -15,16 +15,12 @@ text to mssample1 noshow
 }
 ENDTEXT
 
-
-
 nfopenjson( m.mssample1 )
 browse title 'object'
 ? nfopenjson( m.mssample1,'.stringvalue' )
 browse title 'string'
 ? nfopenjson( m.mssample1,'.arrayValue' )
 browse title 'Array:'
-
-
 
 text to mssample2 noshow
 [
@@ -58,7 +54,6 @@ browse
 
 nfOpenJson( m.msSample2,'$.array')
 browse
-
 
 nfOpenJson( m.mssample2,'$.array',';
  - Number   v(200) $.Order.Number  ;

--- a/nfJson/nfOpenJson.PRG
+++ b/nfJson/nfOpenJson.PRG
@@ -3,7 +3,7 @@
 * usage sample see nfOpenJsonTest.prg
 * refer to https://docs.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql
 *
-* ver 0.91 2019/04/03 - 
+* ver 0.91 2019/04/03 -
 *
 *---------------------------------------------
 parameters cjson, carraypath, cstruct
@@ -24,7 +24,6 @@ endif
 if pcount() < 3
 	return m.cres
 endif
-
 
 =alines( cc, cstruct,7,'-')
 
@@ -52,7 +51,6 @@ isql = rtrim(M.isql,1,',')+' from (cres) where vtooj() into cursor result'
 
 &isql
 
-
 *-------------------------------
 function vtooj()
 *-------------------------------
@@ -75,14 +73,13 @@ if 'as json' $ lower(m.path)
 
 else
 
-	return evaluate(' cast( oj.'+m.path+')') 
+	return evaluate(' cast( oj.'+m.path+')')
 
 endif
 
 *------------------------------------------------------
 function json2kvcursor(cjsonstr,cpropertypath)
 *------------------------------------------------------
-
 
 kk = nfjsonread(m.cjsonstr)
 
@@ -108,7 +105,6 @@ catch
 	lretval = .null.
 endtry
 
-
 do case
 
 case isnull(m.lretval)
@@ -132,7 +128,6 @@ otherwise
 
 	return m.cn
 
-
 endcase
 
 *---------------------------------------------
@@ -153,16 +148,13 @@ for each thisval in aa
 	nitem = m.nitem+1
 endfor
 
-
 *--------------------------------------------------
 function objecttokvtable( ox )
 *--------------------------------------------------
 
 amembers( op, m.ox )
 
-
 for each pname in op
-
 
 	if type('m.oX.&pName',1) = 'A'
 
@@ -187,4 +179,3 @@ for each pname in op
 		( m.pname ,iif(isnull(m.thisval),.null.,cast( m.thisval as m ) ) , vartype( m.thisval ) )
 
 endfor
-

--- a/nfJson/nfcursortojson.prg
+++ b/nfJson/nfcursortojson.prg
@@ -1,20 +1,16 @@
 *-------------------------------------------------------------------
 * Created by Marco Plaza @nfTools
-* ver 1.000 - 20/02/2016 
+* ver 1.000 - 20/02/2016
 *-------------------------------------------------------------------
 parameters returnArray,arrayofValues,includestruct,formattedOutput
 
 LOCAL o
 o = nfCursorToObject( m.arrayOfValues,m.includestruct )
 
-
-IF m.returnArray 
+IF m.returnArray
 	DIMENSION rows(1)
 	ACOPY(m.o.rows,'rows')
 	Return nfJsonCreate(@m.rows,m.formattedOutput,.t.)
 ELSE
 	Return nfJsonCreate(m.o,m.formattedOutput,.t.)
 ENDIF
-
-
-

--- a/nfJson/nfcursortoobject.prg
+++ b/nfJson/nfcursortoobject.prg
@@ -13,14 +13,13 @@ endif
 ovfp = createobject('empty')
 addproperty(ovfp,'arrayOfValues', m.copytoarray )
 
-
 if copytoarray
 
 	copy to array arows
 	recordcount = _tally
 
 	if _tally = 0
-		dimension arows(1) 
+		dimension arows(1)
 		arows(1)  = .null.
 	endif
 
@@ -52,7 +51,6 @@ endif
 addproperty(ovfp,'recordcount', m.recordCount)
 addarray(ovfp,'rows',@m.arows)
 
-
 if m.includestruct
 
 	ncols = afields(astruct)
@@ -64,12 +62,9 @@ if m.includestruct
 
 	addarray(m.ovfp,'aStruct',@m.astruct)
 
-
 endif
 
-
 RETURN m.oVfp
-
 
 ***************************************
 Function addArray(o2add2,aName,a2add)

--- a/nfJson/nfjsoncreate.PRG
+++ b/nfJson/nfjsoncreate.PRG
@@ -1,18 +1,18 @@
 *-------------------------------------------------------------------
 * Created by Marco Plaza @nfTools
-* ver 1.100 - 24/02/2016 
+* ver 1.100 - 24/02/2016
 * enabled collection processing
-* ver 1.101 - 24/02/2016 
+* ver 1.101 - 24/02/2016
 * solved indentation on nested collections
 * ver 1.110 -11/03/2016
 * -added support for collections inside arrays
-* -user can pass aMemembersFlag value 
+* -user can pass aMemembersFlag value
 *  ( since Json is intended for DTO creation default value is 'U' )
 *   check amembers topic on vfp help file for usage
 * changed cr to crlf
 * Added Json validation ; throws error for invalid Json.
 * ver 1.120
-* encode control characters ( chr(0) ~ chr(31) ) 
+* encode control characters ( chr(0) ~ chr(31) )
 *-----------------------------------------------------------------------
 parameters ovfp,formattedOutput,nonullarrayitem,crootName,aMembersFlag
 
@@ -43,7 +43,6 @@ case esarray
 	acopy(ovfp,ojson.array)
 	cjson = procobject(ojson,.f.,m.nonullarrayitem,m.amembersFlag)
 	cJson = substr( m.cJson,at('[',m.cJson))
-
 
 case type('oVfp.BaseClass')='C' and ovfp.baseclass = 'Collection'
 	cjson = procobject(ovfp,.t.,m.nonullarrayitem,m.amembersFlag)
@@ -81,10 +80,9 @@ xtabs = nivel(2)
 
 bc = iif(type('m.obt.baseclass')='C',m.obt.baseclass,'?')
 
-iscollection =  bc = 'Collection' 
+iscollection =  bc = 'Collection'
 
 if m.iscollection
-
 
 	este = m.este+'{ '+m.xtabs
 	xtabs = nivel(2)
@@ -98,23 +96,22 @@ if m.iscollection
 else
 
 	amembers(am,m.obt,0,m.amembersFlag)
-	
+
 	if vartype(m.am) = 'U'
 		xtabs=m.nivel(-2)
 		return ''
 	endif
-
 
 	nm = alen(am)
 
 	for x1 = 1 to m.nm
 
 		var = lower(am(m.x1))
-		
+
 		este = m.este+iif(m.x1>1,',','')+m.xtabs
 
 		este = m.este+["]+strtran(m.var,'_vfpsafe_','')+[":]
-		
+
 		esobjeto = type('m.obt.&Var')='O'
 
 		if type('m.obt.&var') = 'U'
@@ -136,7 +133,7 @@ else
 
 			bc = iif(type('m.thiso.baseclass')='C',m.thiso.baseclass,'?')
 
-			if bc = 'Collection' 
+			if bc = 'Collection'
 
 				este = rtrim(m.este,1,'":')+ collTagName( m.thiso )+'":'
 
@@ -150,22 +147,18 @@ else
 
 		otherwise
 
-
 			este = m.este+concatval(m.obt.&var)
 
 		endcase
 
 	endfor
 
-
 endif
 
 	xtabs = nivel(-2)
 	este  = m.este+m.xtabs
 
-
 return m.este
-
 
 *----------------------------------------------------
 procedure procarray(obt,arrayName,nonullarrayitem)
@@ -209,24 +202,23 @@ do while m.nelem <= m.titems
 
 		else
 
-
 			bc = iif(type('m.elem.baseclass')='C',m.elem.baseclass,'?')
 
-			if bc = 'Collection' 
+			if bc = 'Collection'
 
 				este = m.este+' { "collection'+ collTagName( m.elem )+'":'
-				
+
    				este =  m.este+procobject(m.elem ,.t.,m.nonullarrayitem,m.amembersFlag)
 
 				este = m.este + '}'+m.xTabs+'}'
-				
+
 			else
 
    				este =  m.este+[{]+procobject(m.elem ,.f.,m.nonullarrayitem,m.amembersFlag)+[}]
 
 			endif
 
-			
+
 		endif
 
 	endfor
@@ -240,14 +232,9 @@ do while m.nelem <= m.titems
 
 enddo
 
-
 xtabs=nivel(-2)
 
 este = m.este+m.xtabs+']'
-
-
-
-
 
 *-----------------------------
 function nivel(n)
@@ -270,7 +257,6 @@ if isnull(m.valor)
 	return 'null'
 
 else
-
 
 	tvar = vartype(m.valor)
 	** no cambiar el orden de ejecución!
@@ -296,7 +282,7 @@ endif
 *-----------------------------------
 FUNCTION mustEncode(valor)
 *-----------------------------------
-RETURN len(chrtran(m.valor,specialChars,'')) <> len(m.valor)  
+RETURN len(chrtran(m.valor,specialChars,'')) <> len(m.valor)
 
 *-------------------------------
 function escapeandencode(valun)
@@ -326,8 +312,6 @@ ENDFOR
 
 return RTRIM(m.valun)
 
-
-
 *---------------------------------------------------------------
 Function procCollection(obt,nonullArrayItems,amembersFlag )
 *---------------------------------------------------------------
@@ -353,7 +337,7 @@ With obt
 		este = m.este+Iif(m.x1>1,','+m.xtabs,'')
 
 		If Vartype(m.elem) # 'O'
-		
+
 			este = m.este+Concatval(m.elem)
 
 		else
@@ -368,9 +352,9 @@ With obt
 			endif
 
 			este = m.este+procObject(m.elem, m.isCollection , m.noNullArrayItem, m.aMembersFlag )
-		
+
 			este = m.este+'}'
-		
+
 			if m.isCollection
 				xTabs = nivel(-2)
 				este = m.este+m.xTabs+'}'
@@ -379,7 +363,7 @@ With obt
 		Endif
 
 	endfor
-	
+
 	este = rtrim(m.este,1,m.xTabs)
 
 Endwith

--- a/nfJson/nfjsonread.PRG
+++ b/nfJson/nfjsonread.PRG
@@ -15,7 +15,6 @@ Else
 	calledfrom = ''
 Endif
 
-
 Try
 
 	cerror = ''
@@ -40,11 +39,9 @@ Endif
 
 Return Iif(Vartype(m.ojson)='O',m.ojson,.Null.)
 
-
 *-------------------------------------------------------------------------
 Function nfjsonread2(cjsonstr,revivecollection)
 *-------------------------------------------------------------------------
-
 
 Try
 
@@ -55,7 +52,6 @@ Try
 
 	cjson = Rtrim(Chrtran(m.cjsonstr,Chr(13)+Chr(9)+Chr(10),''))
 	pchar = Left(Ltrim(m.cjson),1)
-
 
 	nl = Alines(aj,m.cjson,20,'{','}','"',',',':','[',']','\\')
 
@@ -84,11 +80,9 @@ Try
 
 	Endcase
 
-
 	If m.revivecollection
 		ojson = revivecollection(m.ojson)
 	Endif
-
 
 Catch To oerr
 
@@ -179,7 +173,6 @@ Do While m.objectopen
 			expecting = Strtran(m.expecting,',','')
 		Endcase
 
-
 	Case m.expectingpropertyname
 
 		If aj(m.x) = '"'
@@ -187,7 +180,6 @@ Do While m.objectopen
 		Else
 			Error 'expecting "'+m.expecting+' got '+aj(m.x)
 		Endif
-
 
 	Case m.expectingvalue
 
@@ -197,17 +189,13 @@ Do While m.objectopen
 			procvalue(m.obj)
 		Endif
 
-
 	Endcase
 
-
 Enddo
-
 
 *-----------------------------------------------------------------------------
 Function anuevoel(obj,arrayname,valasig,bidim,colpos,rowpos)
 *-----------------------------------------------------------------------------
-
 
 If m.bidim
 
@@ -237,7 +225,6 @@ Else
 	Endif
 
 Endif
-
 
 *-----------------------------------------
 Function unescunicode( cstr )
@@ -287,7 +274,6 @@ Endif
 
 Private aa,elem,unesc
 
-
 Declare aa(1)
 =Alines(m.aa,m.value,18,'\\','\b','\f','\n','\r','\t','\"','\/')
 
@@ -336,7 +322,6 @@ expecting = ':'
 expectingvalue = .T.
 expectingpropertyname = .F.
 
-
 *-------------------------------------------------------------
 Procedure procvalue(obj)
 *-------------------------------------------------------------
@@ -364,7 +349,6 @@ Case aj(m.x) = '{'
 
 	Endif
 
-
 Case  aj(x) = '['
 
 	ostack.pusharray()
@@ -378,14 +362,12 @@ Case  aj(x) = '['
 		colpos = 0
 		bidim = .F.
 
-
 		Try
 			AddProperty(obj,(m.arrayname+'(1)'),.Null.)
 		Catch
 			m.arrayname = m.arrayname+'_vfpSafe_'
 			AddProperty(obj,(m.arrayname+'(1)'),.Null.)
 		Endtry
-
 
 	Case m.arraylevel = 1 And !m.bidim
 
@@ -443,8 +425,6 @@ Otherwise
 
 	Endcase
 
-
-
 	If m.isstring
 
 * don't change this lines sequence!:
@@ -489,12 +469,9 @@ Otherwise
 			Error 'expecting "|number|null|true|false|  got '+aj(m.x)
 		Endcase
 
-
 	Endif
 
-
 	If m.arraylevel = 0
-
 
 		AddProperty(obj,m.vari,m.value)
 
@@ -513,7 +490,6 @@ Otherwise
 
 	expecting = Iif(m.isstring,',','')+m.expecting
 
-
 	Do Case
 	Case m.closechar = ']'
 		closearray()
@@ -522,7 +498,6 @@ Otherwise
 	Endcase
 
 Endcase
-
 
 *------------------------------
 Function closearray()
@@ -563,8 +538,6 @@ Else
 
 Endif
 
-
-
 *-------------------------------------
 Procedure closeobject
 *-------------------------------------
@@ -583,7 +556,6 @@ Else
 	expectingvalue = .T.
 	expectingpropertyname = .F.
 Endif
-
 
 *----------------------------------------------
 Function revivecollection( o )
@@ -613,7 +585,6 @@ For x = 1 To m.nprop
 
 		If Not ( Alen(m.tv.collectionItems) = 1 And Isnull( m.tv.collectionItems ) )
 
-
 			For T = 1 To Alen(m.tv.collectionItems)
 
 				If m.keyvalcoll
@@ -621,7 +592,6 @@ For x = 1 To m.nprop
 				Else
 					esteval = m.tv.collectionItems(m.t)
 				Endif
-
 
 				If Vartype(m.esteval) = 'O' Or Type('esteVal',1) = 'A'
 					esteval = revivecollection(m.esteval)
@@ -661,7 +631,6 @@ For x = 1 To m.nprop
 
 	Endcase
 
-
 	estavar = Strtran( m.estavar,'_KV_COLLECTION', '' )
 	estavar = Strtran( m.estavar, '_KL_COLLECTION', '' )
 
@@ -689,7 +658,6 @@ Else
 	Return m.oconv
 Endif
 
-
 *----------------------------------
 Function isjsondt( cstr )
 *----------------------------------
@@ -706,7 +674,6 @@ Return Iif( Len(m.cstr) = 19 ;
 	and Occurs('T',m.cstr) = 1 ;
 	and Occurs('-',m.cstr) = 2 ;
 	and Occurs(':',m.cstr) = 2 ,.T.,.F. )
-
 
 *-----------------------------------------------------
 Procedure jsondatetodt( cjsondate )

--- a/nfJson/nfjsontocursor.PRG
+++ b/nfJson/nfjsontocursor.PRG
@@ -5,19 +5,16 @@
 *-------------------------------------------------------------------
 Parameters  cJson, cName, forceImportFromArray
 
-
-
 cName = Evl(m.cName,Sys(2015))
 
 Private All
 
 oCursor = nfJsonRead(m.cJson)
 
-
 do case
  CASE VARTYPE(oCursor) # 'O'
- 	return 
- case Vartype(oCursor.aStruct) = 'U' 
+ 	return
+ case Vartype(oCursor.aStruct) = 'U'
 	Error  'missing structure data - must create json using nfCursor2Json4vfp() '
 	return
  case !m.forceImportFromArray and Vartype(oCursor.asarray) = 'L' and oCursor.asarray
@@ -25,7 +22,7 @@ do case
  	or use forceImportFromArray only if you are sure your data contains no memo or binary types'
 	return
 endcase
- 
+
 Create Cursor (m.cName) From Array oCursor.aStruct
 
 If oCursor.recordCount = 0

--- a/nfJson/performanceTest/nfjsonperftest.PRG
+++ b/nfJson/performanceTest/nfjsonperftest.PRG
@@ -1,7 +1,7 @@
 *************************************************************
 *  just for testing purposes.
-*  you can  add your sample json 
-* strings to  nfJsonPerfTest.txt 
+*  you can  add your sample json
+* strings to  nfJsonPerfTest.txt
 *
 * delimit your json file using 3 Double quotes <sample name> and a colon :
 *
@@ -19,7 +19,7 @@ IF  _vfp.StartMode # 4 and UPPER(RIGHT(CURDIR(),24)) # upper('\nfJson\performanc
 	RETURN
 ENDIF
 
-SET PATH TO ..\   && nfJson folder 
+SET PATH TO ..\   && nfJson folder
 
 m.testFile = JUSTPATH(SYS(16,0))+'\nfjsonperftestSamples.TXT'
 
@@ -29,7 +29,6 @@ IF !FILE(m.testFile)
 ELSE
 	cjson = FILETOSTR(m.testFile)
 ENDIF
-
 
 Dimension opt(1)
 N=1
@@ -62,7 +61,6 @@ Define Class sampletest As Form
 	Add Object deCliptext As CommandButton With Anchor=6,Left =10, Top = 560, Height=30, Width=160 , Caption='Json from clipboard',FontName='Consolas',FontSize=10
 	Add Object TRESULT As TextBox With Anchor=6,Left=200,Height=25,Width=550,Top=565,fontname='Consolas',FontSize=10
 
-
 	Procedure Init
 	This.Visible = .T.
 	This.samples.RowSource='opt'
@@ -81,12 +79,10 @@ Catch to oerr
 
 EndTry
 
-
 *-------------------------------------
 	Procedure samples.Click()
 *-------------------------------------
 	Thisform.procesarJson( Strextract(cjson,opt(This.ListIndex)+':','"""') )
-
 
 *------------------------------------------
 	Function procesarJson(jText)
@@ -107,7 +103,6 @@ EndTry
 			exit
 		endif
 	Endfor
-
 
 	TR=(Seconds()-TI)*millon
 


### PR DESCRIPTION
If merged, this Pull Request replaces all instances of 3 or more carriage returns to 2 carriage returns.

I was reading the code in this repo on my 15" MacBook Pro and I was shocked to sometimes see just 12 or 13 lines of code in a fully vertically maximized VS code window.  The code, in its prior state, seems to waste vertical space far in excess of what's normal.

This PR fixes that.  2 blank lines maximum, everywhere.  Eliminating all instances of 3, 4, 5.... blank lines.