### PR TITLE
Fix in "nfcursortoobject.prg" - Error processing tables with field "aname"

### DIFF
--- a/nfJson/nfcursortoobject.prg
+++ b/nfJson/nfcursortoobject.prg
@@ -67,9 +67,9 @@ endif
 RETURN m.oVfp
 
 ***************************************
-Function addArray(_o2add2,_aName,_a2add)
+Function addArray(o2add2,aName,a2add)
 ***************************************
 
-AddProperty(_o2add2,(_aName+'(1)'))
+AddProperty(o2add2,(aName+'(1)'))
 
-Acopy(_a2add,_o2add2.&_aName)
+Acopy(a2add,o2add2.&aName)

--- a/nfJson/nfcursortoobject.prg
+++ b/nfJson/nfcursortoobject.prg
@@ -67,9 +67,9 @@ endif
 RETURN m.oVfp
 
 ***************************************
-Function addArray(o2add2,aName,a2add)
+Function addArray(_o2add2,_aName,_a2add)
 ***************************************
 
-AddProperty(o2add2,(aName+'(1)'))
+AddProperty(_o2add2,(_aName+'(1)'))
 
-Acopy(a2add,o2add2.&aName)
+Acopy(_a2add,_o2add2.&_aName)

--- a/nfJson/nfjsoncreate.PRG
+++ b/nfJson/nfjsoncreate.PRG
@@ -267,6 +267,10 @@ else
 		vc = iif(m.valor,'true','false')
 	case m.tvar $ 'DT'
 		vc = ["]+ttoc(m.valor,3)+[Z"]
+		*** We don´t want an empty VFP date-value like "0000-00-00T00:00:00Z"
+		IF vc = '"0000-00-00T00:00:00Z"'
+			vc = 'null'
+		ENDIF 
 	case mustEncode(m.valor)
 		vc = ["]+escapeandencode(m.valor)+["]
 	case m.tvar $ 'CVM'


### PR DESCRIPTION
Fix for existing projects in which some tables actually have a field named "aname" in them.

Please share your thoughts. Thanks.

Example VFP cursor for testing:
====================
CREATE CURSOR curDatenKita (;
	Mandant_Adressennr I, KitaName C(50), ;
	TraegerArt I, TraegerRechtsform I, ;
	FruehBetreuung I, FruehbetreuungZeit C(5), ;
	SpaetBetreuung I, SpaetbetreuungZeit C(5), ;
	AusschBetrieb I, ElternInit I, ;
	Plaetze I, Gruppen I, OhneStruktur I, Kinder I, EinrichtungsNr  N(10,0),;
	EName1 C(50), EName2 C(50), EName3 C(50), EStr C(50), EPlz C(50), EOrt C(50), ;
	TName1 C(50), TName2 C(50), TName3 C(50), TStr C(50), TPlz C(50), TOrt C(50), ;
	AName C(50), ATelefon C(50), AFax C(50), AEMail C(50))