### PR TITLE
performance improvements

### DIFF
--- a/nfJson/nfjsoncreate.PRG
+++ b/nfJson/nfjsoncreate.PRG
@@ -310,39 +310,39 @@ valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
 																chr(127),'\b')
 valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
 																chr(0),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(1),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(2),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(3),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(4),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(5),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(6),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(7),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(8),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(9),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(10),'\u'+RIGHT(TRANSFORM(0,'@0'),4))
+																chr(1),'\u'+RIGHT(TRANSFORM(1,'@0'),4)),;
+																chr(2),'\u'+RIGHT(TRANSFORM(2,'@0'),4)),;
+																chr(3),'\u'+RIGHT(TRANSFORM(3,'@0'),4)),;
+																chr(4),'\u'+RIGHT(TRANSFORM(4,'@0'),4)),;
+																chr(5),'\u'+RIGHT(TRANSFORM(5,'@0'),4)),;
+																chr(6),'\u'+RIGHT(TRANSFORM(6,'@0'),4)),;
+																chr(7),'\u'+RIGHT(TRANSFORM(7,'@0'),4)),;
+																chr(8),'\u'+RIGHT(TRANSFORM(8,'@0'),4)),;
+																chr(9),'\u'+RIGHT(TRANSFORM(9,'@0'),4)),;
+																chr(10),'\u'+RIGHT(TRANSFORM(10,'@0'),4))
 valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
-																chr(11),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(12),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(13),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(14),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(15),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(16),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(17),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(18),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(19),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(20),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(21),'\u'+RIGHT(TRANSFORM(0,'@0'),4))
+																chr(11),'\u'+RIGHT(TRANSFORM(11,'@0'),4)),;
+																chr(12),'\u'+RIGHT(TRANSFORM(12,'@0'),4)),;
+																chr(13),'\u'+RIGHT(TRANSFORM(13,'@0'),4)),;
+																chr(14),'\u'+RIGHT(TRANSFORM(14,'@0'),4)),;
+																chr(15),'\u'+RIGHT(TRANSFORM(15,'@0'),4)),;
+																chr(16),'\u'+RIGHT(TRANSFORM(16,'@0'),4)),;
+																chr(17),'\u'+RIGHT(TRANSFORM(17,'@0'),4)),;
+																chr(18),'\u'+RIGHT(TRANSFORM(18,'@0'),4)),;
+																chr(19),'\u'+RIGHT(TRANSFORM(19,'@0'),4)),;
+																chr(20),'\u'+RIGHT(TRANSFORM(20,'@0'),4)),;
+																chr(21),'\u'+RIGHT(TRANSFORM(21,'@0'),4))
 valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
-																chr(22),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(23),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(24),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(25),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(26),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(27),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(28),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(29),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(30),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
-																chr(31),'\u'+RIGHT(TRANSFORM(0,'@0'),4))
+																chr(22),'\u'+RIGHT(TRANSFORM(22,'@0'),4)),;
+																chr(23),'\u'+RIGHT(TRANSFORM(23,'@0'),4)),;
+																chr(24),'\u'+RIGHT(TRANSFORM(24,'@0'),4)),;
+																chr(25),'\u'+RIGHT(TRANSFORM(25,'@0'),4)),;
+																chr(26),'\u'+RIGHT(TRANSFORM(26,'@0'),4)),;
+																chr(27),'\u'+RIGHT(TRANSFORM(27,'@0'),4)),;
+																chr(28),'\u'+RIGHT(TRANSFORM(28,'@0'),4)),;
+																chr(29),'\u'+RIGHT(TRANSFORM(29,'@0'),4)),;
+																chr(30),'\u'+RIGHT(TRANSFORM(30,'@0'),4)),;
+																chr(31),'\u'+RIGHT(TRANSFORM(31,'@0'),4))
 
 return RTRIM(m.valun)
 

--- a/nfJson/nfjsoncreate.PRG
+++ b/nfJson/nfjsoncreate.PRG
@@ -250,7 +250,7 @@ endif
 function concatval(valor)
 *-----------------------------
 
-#define specialChars ["\/]+chr(127)+chr(12)+chr(10)+chr(13)+chr(9)+CHR(0)+CHR(1)+CHR(2)+CHR(3)+CHR(4)+CHR(5)+CHR(6)+CHR(7)+CHR(8)+CHR(9)+CHR(10)+CHR(11)+CHR(12)+CHR(13)+CHR(14)+CHR(15)+CHR(16)+CHR(17)+CHR(18)+CHR(19)+CHR(20)+CHR(21)+CHR(22)+CHR(23)+CHR(24)+CHR(25)+CHR(26)+CHR(27)+CHR(28)+CHR(29)+CHR(30)+CHR(31)
+#define specialChars ["\]+chr(127)+CHR(0)+CHR(1)+CHR(2)+CHR(3)+CHR(4)+CHR(5)+CHR(6)+CHR(7)+CHR(8)+CHR(9)+CHR(10)+CHR(11)+CHR(12)+CHR(13)+CHR(14)+CHR(15)+CHR(16)+CHR(17)+CHR(18)+CHR(19)+CHR(20)+CHR(21)+CHR(22)+CHR(23)+CHR(24)+CHR(25)+CHR(26)+CHR(27)+CHR(28)+CHR(29)+CHR(30)+CHR(31)
 
 if isnull(m.valor)
 
@@ -287,28 +287,62 @@ RETURN len(chrtran(m.valor,specialChars,'')) <> len(m.valor)
 *-------------------------------
 function escapeandencode(valun)
 *-------------------------------
-valun = strtran(m.valun,'\','\\')
-valun = strtran(m.valun,'"','\"')
-*valun = Strtran(m.valun,'/','\/')
+*valun = strtran(m.valun,'\','\\')
+*valun = strtran(m.valun,'"','\"')
+*valun = strtran(m.valun,chr(9),'\t')
+*valun = strtran(m.valun,chr(10),'\n')
+*valun = strtran(m.valun,chr(12),'\f')
+*valun = strtran(m.valun,chr(13),'\r')
+*valun = strtran(m.valun,chr(127),'\b')
 
-IF !mustEncode(m.valun)
-	RETURN
-ENDIF
+*LOCAL x
+*FOR x = 0 TO 31
+*	valun = strtran(m.valun,chr(m.x),'\u'+RIGHT(TRANSFORM(m.x,'@0'),4))
+*ENDFOR
 
-valun = strtran(m.valun,chr(127),'\b')
-valun = strtran(m.valun,chr(12),'\f')
-valun = strtran(m.valun,chr(10),'\n')
-valun = strtran(m.valun,chr(13),'\r')
-valun = strtran(m.valun,chr(9),'\t')
-
-IF !mustEncode(m.valun)
-	RETURN
-ENDIF
-
-LOCAL x
-FOR x = 0 TO 31
-	valun = strtran(m.valun,chr(m.x),'\u'+RIGHT(TRANSFORM(m.x,'@0'),4))
-ENDFOR
+valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
+																'\','\\'),;
+																'"','\"'),;
+																chr(9),'\t'),;
+																chr(10),'\n'),;
+																chr(12),'\f'),;
+																chr(13),'\r'),;
+																chr(127),'\b')
+valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
+																chr(0),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(1),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(2),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(3),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(4),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(5),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(6),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(7),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(8),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(9),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(10),'\u'+RIGHT(TRANSFORM(0,'@0'),4))
+valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
+																chr(11),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(12),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(13),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(14),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(15),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(16),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(17),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(18),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(19),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(20),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(21),'\u'+RIGHT(TRANSFORM(0,'@0'),4))
+valun = strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(strtran(m.valun,;
+																chr(22),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(23),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(24),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(25),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(26),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(27),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(28),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(29),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(30),'\u'+RIGHT(TRANSFORM(0,'@0'),4)),;
+																chr(31),'\u'+RIGHT(TRANSFORM(0,'@0'),4))
 
 return RTRIM(m.valun)
 

--- a/nfJson/performanceTest/nfjsonperftest.PRG
+++ b/nfJson/performanceTest/nfjsonperftest.PRG
@@ -12,7 +12,7 @@
 *************************************************************
 
 #define millon 1000000
-Public oJson
+Public oJson, nsamp
 
 IF  _vfp.StartMode # 4 and UPPER(RIGHT(CURDIR(),24)) # upper('\nfJson\performanceTest\')
 	MESSAGEBOX('Please run from nfJson\performanceTest',0)
@@ -32,7 +32,7 @@ ENDIF
 
 Dimension opt(1)
 N=1
-nsamp = 10
+nsamp = 75
 
 Do While .T.
 	op=Strextract(cjson,'"""',':',N)
@@ -49,17 +49,19 @@ Read Events
 
 Define Class sampletest As Form
 
-	Height = 600
-	Width= 800
-	ShowWindow = 2
+	Height=680
+	Width=900
+	ShowWindow=2
 	Left=300
 	Top=100
-	caption = 'nfJson 1.0000'
-
-	Add Object samples As ListBox With 	Anchor=7,Left=10,Top=5,Height = 550,Width = 190,RowSourceType=5,FontName='Consolas',FontSize=10
-	Add Object json As EditBox With 	Anchor=15,Left=195,Top=5,Height = 550,Width = 600,RowSourceType=5,FontName='Consolas',FontSize=10
-	Add Object deCliptext As CommandButton With Anchor=6,Left =10, Top = 560, Height=30, Width=160 , Caption='Json from clipboard',FontName='Consolas',FontSize=10
-	Add Object TRESULT As TextBox With Anchor=6,Left=200,Height=25,Width=550,Top=565,fontname='Consolas',FontSize=10
+	caption='nfJson 1.0000'
+	
+	Add Object lblsamplesize As Label With Left=10,Height=25,Width=235,Top=14,fontname='Consolas',FontSize=11,Caption="Number of Samples to be used:"
+	Add Object txtsamplesize As TextBox With Left=250,Height=25,Width=60,Top=10,fontname='Consolas',FontSize=11,Format="KZ",Inputmask="99999",Controlsource="nsamp"
+	Add Object samples As ListBox With Anchor=7,Left=10,Top=40,Height = 595,Width = 235,RowSourceType=5,FontName='Consolas',FontSize=10
+	Add Object json As EditBox With Anchor=15,Left=250,Top=40,Height = 595,Width = 640,RowSourceType=5,FontName='Consolas',FontSize=10
+	Add Object deCliptext As CommandButton With Anchor=6,Left =9, Top = 640, Height=30, Width=237 , Caption='Json from clipboard',FontName='Consolas',FontSize=11
+	Add Object TRESULT As TextBox With Anchor=6,Left=250,Height=28,Width=640,Top=641,fontname='Consolas',FontSize=11
 
 	Procedure Init
 	This.Visible = .T.
@@ -92,7 +94,10 @@ EndTry
 		Messagebox('No es Texto!',0)
 		Return .F.
 	Endif
-
+	
+* indicator that results are being recalculated
+	Thisform.TRESULT.ForeColor = RGB(255,0,0)
+	
 * transform sample json data into vfp Object:
 	TI=Seconds()
 
@@ -120,6 +125,7 @@ EndTry
 	TR2=(Seconds()-TI)*millon
 	TR2=round(TR2/nsamp,0)
 
+	Thisform.TRESULT.ForeColor = RGB(0,0,0)
 	Thisform.TRESULT.Value = ' Read: '+Transform(TR,'99,999')+'us  ( '+Transform(millon/TR,'99,999')+' op/sec )   Create: '+Transform(TR2,'99,999')+'us  ( '+Transform(millon/TR2,'99,999')+' op/sec )'
 
 	Thisform.json.SelStart=1

--- a/nfJson/performanceTest/nfjsonperftestSamples.TXT
+++ b/nfJson/performanceTest/nfjsonperftestSamples.TXT
@@ -3180,4 +3180,105 @@
   }]
 }
 
+""" Child-Care Informations:
+
+[
+   {
+      "aid":1,
+      "aname":"DRK Kindertagesstätte \"Sprungweg\"",
+      "awebsite":"http://www.google.de/kita1",
+      "aemail":"Kindertagesstätte-Sprungweg@kita-demo-mail.de",
+      "atelefon1":"0441 / 394 - 175",
+      "atelefon2":"0441 / 394 - 9175",
+      "ainfo1_text":"Unser Team bietet jedem Kind einen verlässlichen Partner im strukturierten Tagesablauf und eine feste Bezugsperson, da jedes Kind einer Stammgruppe angehörig ist. Tägliche Angebote, z. B. der Morgenkreis in der Stammgruppe, bieten den Kindern Struktur und Orientierung innerhalb der Offenen Arbeit. \r\n\r\nPädagogische Schwerpunkte der einzelnen Fachkraft finden sich in verschiedenen Angeboten, wie z. B. Fußball/Turnen, Experimente oder Basteln, wieder und können von den Kindern ausgewählt werden. Ein täglich festes Angebot ist unsere Draußenzeit, sie findet mittags statt. Die Kinder werden täglich in ihrer Sprachentwicklung unterstützt. Durch gezielte Angebote in Kleingruppen können wir auf die Bedürfnisse und den Entwicklungsstand der Kinder eingehen.",
+      "ainfo1_type":"1/Verpflegung",
+      "ainfo2_text":"Der Tag beginnt in unserem Haus mit einem Frühstück, das die Küche morgens zubereitet. Unser Essraum ist elternfreie Zone, da die Kinder die Möglichkeit haben sollen, ihr Frühstück und die Menge selbst zu wählen. Ein pädagogischer Mitarbeiter steht ihnen dabei als Ansprechpartner zur Verfügung. \r\n\r\nDas Mittagessen findet in festen Gruppen statt und wird täglich von unseren Küchenkräften frisch gekocht. Wir animieren Kinder dazu, Gerichte zu probieren. Aber auch hier lernt das Kind selbst zu wählen und Mengen richtig einzuschätzen. Nach dem Essen geben die Kinder Feedback zum Gericht, das an die Küche weitergeleitet wird.",
+      "ainfo2_type":"2/Räumlichkeit",
+      "ainfo3_text":"Wer in unser Haus kommt geht zunächst am Büro vorbei und steht dann im Mittelpunkt des Hauses: dem Großraum. Er dient als Raum für Bewegungsangebote, für die Vollversammlung zu Geburtstagen oder gemeinsames Singen. \r\n\r\nUnsere Funktionsräume, z. B. die Baustelle, ABC Höhle oder die Spieleoase, werden auch als Gruppenräume genutzt.",
+      "ainfo3_type":"3/Außenanlagen",
+      "ainfo4_text":"Unser Außengelände verfügt über viel grüne Rasenspielfläche, einen kleinen Fußballplatz und einen Spielplatz. Die gepflasterten Wege werden gerne von den Kindern zum Dreiradfahren genutzt.\r\n",
+      "ainfo4_type":"4/Pädagogisches Konzept"
+   },
+   {
+      "aid":6,
+      "aname":"ev. Kindergarten \"Schlaumäuse\"",
+      "awebsite":"http://www.google.de/kita6",
+      "aemail":"Kindergarten-Schlaumaeuse@kiga-demo-mail.de",
+      "atelefon1":"0441 / 394 - 006",
+      "atelefon2":"0441 / 394 - 9006",
+      "ainfo1_text":"Unsere weitläufigen, sonnigen und hellen Räumlichkeiten laden zum Spielen, Forschen, Entdecken und Ruhen ein. Im Garten ist viel Platz zum Klettern, Fußballspielen, Buddeln und Toben. \r\n\r\nDer Gemüse- und Kräutergarten bietet die Möglichkeit zu pflanzen, ernten, riechen, schmecken und fühlen. Die überdachten Innenhöfe bieten auch bei \"Schmuddelwetter\" luftige Spielflächen. In geschütztem Rahmen entdecken und erobern sich die Kinder die Möglichkeiten unseres Hauses.",
+      "ainfo1_type":"1/Verpflegung",
+      "ainfo2_text":"In unserem Kindergarten bieten wir den Kindern täglich ein gesundes und leckeres Mittagessen an. Großen Wert legen wir dabei auf viel Selbstgekochtes sowie frisches Obst und Gemüse. Ergänzt wird unser Essensangebot durch einige Komponenten kindgerechter Tiefkühlkost. Wöchentlich gibt es dabei zweimal Fleisch, einmal Fisch und zweimal vegetarische Gerichte.\r\n",
+      "ainfo2_type":"2/Räumlichkeit",
+      "ainfo3_text":"Unser Kindergarten bietet viele unterschiedlich gestaltete Räume und anregende Materialien, die die Kinder täglich neu für ihr Spiel wählen können:    - Kreativraum  - Musik- und Rollenspielraum  - Bücher- und Spieleraum  - Natur- und Forscherraum  - Bauraum  - Werkraum  - Turnhalle  - Planschraum  - Hort- und Hausaufgabenräume  - Ruheraum  - Groß- und Bewegungsraum.\r\n\r\nDazu ein großes Außengelände, ein Gemüse- und Kräutergarten, ein Fußballplatz und eine Feuerstelle.",
+      "ainfo3_type":"3/Außenanlage",
+      "ainfo4_text":"Unser großflächiges und interessant gestaltetes Außengelände bietet den Kindern ein reichhaltiges Erlebnisangebot. Hier können sie klettern und schaukeln, im Sand spielen und sich auf unserem Fußballplatz austoben. Die Kinder forschen und entdecken, matschen und bauen. \r\n\r\nIn unserem anliegenden Kräuter- und Pflanzengarten können sie sähen, gießen und ernten. Gemeinsam verarbeiten wir anschließend die Ernte, z. B. zu Salaten, Marmeladen, Rohkost, Kuchen und und und…",
+      "ainfo4_type":"4/Pädagogisches Konzept"
+   },
+   {
+      "aid":17,
+      "aname":"Hort Grundschule \"Sausewind\"",
+      "awebsite":"http://www.google.de/kita17",
+      "aemail":"Hort-Grundschule-Sandweg@kiga-demo-mail.de",
+      "atelefon1":"0441 / 394 - 171",
+      "atelefon2":"0441 / 394 - 9171",
+      "ainfo1_text":"Bei der Planung des Alltags arbeiten wir nach einem ganzheitlichen Ansatz, der die tägliche Erlebniswaelt des Kindes in den Mittelpunkt stellt. Jedes Kind wird als eingeständige Persönlichkeit angenommen und in seinem sozialen, körperlichen, geistigen und seelischen Fähigkeiten unterstützt. \r\n\r\nEin Schwerpunkt unserer Arbeit ist, die Kinder an allen sie betreffenden Entscheidungen zu beteiligen. Gewählte Kinderabgeordnete treffen sich regelmäßig um die sie betreffenden Themen zu besprechen und Entscheidungen zu treffen.  Ein weiterer Schwerpunkt ist die Sprachentwicklung- und Förderung. Wir nehmen am Bundesprogramm \"Sprach-Kitas\" : Weil Sprache der Schlüssel zur Welt ist\", teil.",
+      "ainfo1_type":"1/Verpflegung",
+      "ainfo2_text":"Die gemeinsamen Mahlzeiten werden in angenehmer, ruhiger Atmosphäre eingenommen. Das Frühstück und die Zwischenmahlzeit am Nachmittag werden zusammen mit den Kindern geplant, die Zutaten gemeinsam eingekauft und zubereitet. Ein ansprechend gedeckter Tisch motiviert zu angeregten Gesprächen und zeigt auf, Essen als Genuss zu erleben. Die Kinder entscheiden selbst, ob, was und wieviel sie essen. \r\n\r\nIn unserer Küche wird täglich frisch gekocht. Dabei wird auf kindgerechte, ausgewogene und gesunde Ernährung, sowie auf regionale und saisonale Produkte geachtet. Nach dem Mittagessen stimmen die Kinder ab, wie es geschmeckt hat.   Zu besonderen Anlässen findet zwei bis drei Mal im Jahr in der großen Halle ein gemeinsames Frühstück mit Büffet statt.",
+      "ainfo2_type":"2/Räumlichkeit",
+      "ainfo3_text":"Die helle und großzügig angelegte Halle ist Mittelpunkt unseres Hauses. Sie bietet vielfältige Spiel- und Bewegungsangebote für die Kinder aller Gruppen.   Die sechs Gruppenräume sind individuell gestaltet und ausgestattet. Jede Gruppe hat einen direkten Zugang über die Terrasse zum Außengelände und einen eigenen Waschraum.   Die bunten Bälle im Bällebad locken zum Untertauchen und zum Hineinspringen. So wird auf einfache Weise die taktile und visuelle Wahrnehmung gefördert. \r\n\r\nFür eine gesunde körperliche Entwicklung brauchen Kinder ausreichend Bewegungserfahrung. In der Turnhalle finden die Kinder viele Möglichkeiten, ihren ganzen Körper zu spüren und wahrzunehmen.",
+      "ainfo3_type":"3/Außenanlagen",
+      "ainfo4_text":"Über Bewegung erleben Kinder sich und ihre Umwelt. Bewegung hilft ihnen, selbstständig zu werden und stärkt das Selbstbewusstsein. Sie entdecken Neues, erwerben körperliche, kognitive und soziale Kompetenzen und entwickeln sich weiter. Unser Außengelände bietet dafür vielfältige Möglichkeiten.\r\n",
+      "ainfo4_type":"4/Pädagogisches Konzept"
+   },
+   {
+      "aid":22,
+      "aname":"Kindergarten \"Die wilden Zwerge\"",
+      "awebsite":"http://www.google.de/kita22",
+      "aemail":"Kindergarten-Drosselgasse@kiga-demo-mail.de",
+      "atelefon1":"0441 / 394 - 002",
+      "atelefon2":"0441 / 394 - 9002",
+      "ainfo1_text":"Unsere Arbeit ist offene Arbeit, so entstehen pädagogische Schwerpunkte nicht nur durch unser pädagogisches Angebot sondern ebenso durch die Ideen und Wünsche Ihrer Kinder. \r\n\r\nWir selbst legen großen Wert auf die Bereiche Bewegung, Kreativität, Naturwissenschaften, Sprache und Konzentrationsförderung sowie auf gut gelungene Übergänge zwischen Kita und Schule.",
+      "ainfo1_type":"1/Verpflegung",
+      "ainfo2_text":"Wir legen großen Wert auf eine gesunde und ausgewogene Ernährung. Kinder bringen ihr Frühstück und einen Nachmittagsimbiss selbst mit. Mittags kochen wir täglich frisch in unserer eigenen Küche. \r\n\r\nEine Portion Obst sowie Gemüse ist immer da und einmal in der Woche machen wir ein Müslifrühstück. Sollte Ihr Kind eine spezielle Ernährung benötigen, so sprechen Sie uns bitte an.",
+      "ainfo2_type":"2/Räumlichkeit",
+      "ainfo3_text":"Die Räumlichkeiten haben durch die offene Arbeit klar strukturierte und feste Inhalte. So können Kinder ihre Fertigkeiten im Atelier, Wahrnehmungsraum, Puzzle- und Bilderbuchzimmer, Bauraum, Naturwissenschaftsraum, Bewegungsraum (Großraum) sowie in den Krippen- und Horträumen erweitern. \r\n",
+      "ainfo3_type":"3/Außenanlagen",
+      "ainfo4_text":"Unsere Außenanlagen sind sehr naturbelassen und ermöglichen Kindern viel Bewegung. Die Schwerpunkte liegen in Ball- und Bewegungsspielen, in unserem Niedrigseilgarten sowie in der Entdeckung der Elemente Wasser, Feuer und Luft.\r\n",
+      "ainfo4_type":"4/Pädagogisches Konzept"
+   },
+   {
+      "aid":24,
+      "aname":"Kindergarten \"Haus der bunten Träume\"",
+      "awebsite":"http://www.google.de/kita24",
+      "aemail":"Kindergarten-Sonnenblume@kiga-demo-mail.de",
+      "atelefon1":"0441 / 394 - 004",
+      "atelefon2":"0441 / 394 - 9004",
+      "ainfo1_text":"Durch Projekte und Aktivitäten, funktionsbezogene Raumgestaltungen sowie vielfältige Materialien machen wir Kindern in der offenen Arbeit interessante und spannende Angebote für eine ganzheitliche Entwicklung. \r\n\r\nDas Erlernen sozialer Kompetenzen und der Umgang miteinander in Gruppen sind dabei ebenso wichtig wie die Förderung kognitiver Fähigkeiten und die Auseinandersetzung mit Sachthemen.",
+      "ainfo1_type":"1/Verpflegung",
+      "ainfo2_text":"In unserer Küche wird täglich mit hochwertigen Zutaten abwechslungsreich und frisch gekocht. \r\n\r\nEs steht jederzeit frisches Obst und Gemüse zum Zugreifen bereit und einmal wöchentlich findet ein Müslifrühstück statt.",
+      "ainfo2_type":"2/Räumlichkeit",
+      "ainfo3_text":"Treff- und Mittelpunkt unseres Kinderhauses ist der Großraum. Von hier aus gelangt man in viele unterschiedlich gestaltete Räume mit Materialien, die die Kinder täglich neu für ihr Spiel wählen können.\r\n",
+      "ainfo3_type":"3/Außenanlagen",
+      "ainfo4_text":"Unser großzügig angelegtes Außengelände umringt das gesamte Kinderhaus. Es lädt zu vielfältigen Sinnes- und Bewegungserfahrungen ein und bietet den Kindern ein reiches Angebot an Körpererfahrungen sowie Raum für Spiel und Abenteuer. Das Wäldchen, die Büsche und die grünen Höhlen laden zur Exkursion ein und bieten den Kindern gute Verstecke und Rückzugsmöglichkeiten.\\",
+      "ainfo4_type":"4/Konzept"
+   },
+   {
+      "aid":73,
+      "aname":"Tagespflegebüro \"Familienhilfe\" Kösliner Weg",
+      "awebsite":"http://www.google.de/73",
+      "aemail":"Tagespflegebuero-Koesliner-Weg@kiga-demo-mail.de",
+      "atelefon1":"0441 / 394 - 173",
+      "atelefon2":"0441 / 394 - 9173",
+      "ainfo1_text":"Die Tagespflegepersonen leisteen mit Einfühlungsvermögen, Umsichtigkeit und Kreativität die Betreuungs-, Erziehungs- und Bildungsarbeit. Ihre Arbeit ist darauf ausgerichtet, die Fähigkeiten jedes Kindes zu erkennen, zu achten und seine Entwicklungsschritte zu begleiten und zu unterstützen. Dafür gibt sie den Kindern Zeit, Raum und Sicherheit.  Das Kind lernt durch den Umgang mit anderen Kindern viele neue Dinge kennen, die seinen Forscherdrang wecken und es zu neuen Experimenten ermuntern.   \r\n\r\nDie Räume in der Tagespflege sind so ausgestattet, dass sie den Kindern Vertrautheit und Wärme geben und ihre individuellen Bedürfnisse berücksichtigen.",
+      "ainfo1_type":"1/Allgemein",
+      "ainfo2_text":"Über Bewegung erleben Kinder sich und ihre Umwelt. Bewegung hilft ihnen, selbstständig zu werden und stärkt das Selbstbewusstsein. Sie entdecken Neues, erwerben körperliche, kognitive und soziale Kompetenzen und entwickeln sich weiter. Unser Außengelände bietet dafür vielfältige Möglichkeiten.\r\n",
+      "ainfo2_type":"2/Pädagogisches Konzept",
+      "ainfo3_text":"Die helle und großzügig angelegte Halle ist Mittelpunkt unseres Hauses. Sie bietet vielfältige Spiel- und Bewegungsangebote für die Kinder aller Gruppen.   Die sechs Gruppenräume sind individuell gestaltet und ausgestattet. Jede Gruppe hat einen direkten Zugang über die Terrasse zum Außengelände und einen eigenen Waschraum.   Die bunten Bälle im Bällebad locken zum Untertauchen und zum Hineinspringen. So wird auf einfache Weise die taktile und visuelle Wahrnehmung gefördert. \r\n\r\nFür eine gesunde körperliche Entwicklung brauchen Kinder ausreichend Bewegungserfahrung. In der Turnhalle finden die Kinder viele Möglichkeiten, ihren ganzen Körper zu spüren und wahrzunehmen.",
+      "ainfo3_type":"3/Räumlichkeiten",
+      "ainfo4_text":null,
+      "ainfo4_type":null
+   }
+]
+
 """


### PR DESCRIPTION
TL;DR
- create json with special characters is now significantly faster (changes made in function "escapeandencode")
- updated performance test & added new test sample
 
===========

Overall summary:
I have used the included performance test (with largely increased sample size) to get an approximate idea for the performance change. Without special characters in json performance does not change. With at least one special character in json the improvements can be measured (depending on overall json size). When "/" is the only special character in json then it speeds up significantly, because "/" was already no longer threated as special character in funtion "escapeandencode".

Changes in json create:
+33% more op/sec - flicker
+53% more op/sec - Google Maps Basic Query
+27% more op/sec - Youtube
+21% more op/sec - facebook
+44% more op/sec - Tweeter 1
+23% more op/sec - Tweeter 2
+53% more op/sec - Tweeter 3
+18% more op/sec - Tweeter 4
+17% more op/sec - Sample Konfabulator Widget
+36% more op/sec - cofaxCDS
+32% more op/sec - Cursor Rows
+31% more op/sec - Amazon S3
+24% more op/sec - dropBox
+32% more op/sec - tropical index
+41% more op/sec - jSON Benchmark
+15% more op/sec - Map Quest
+12% more op/sec - Bing
+28% more op/sec - JSONAPI
+36% more op/sec - Child-Care Informations
=> other samples have no significant change in op/sec (less than +5%).

=====================

More detailed explanation:

*nfjsoncreate.prg / variable "specialChars"*
- removed multiple instances of the same character from variable "specialChars"
- removed character "/" from variable "specialChars", because for this character there is already no more encoding done in function "escapeandencode". Depending on the data some strings do not call the function "escapeandencode" anymore. 

*nfjsoncreate.prg / function "escapeandencode"*
- removed unnecessary checks for "mustencode", because none of the special characters will be removed till then (even if it would, then the call of "RETURN" would throw an error, because a string is expected as return value and not a boolean ".F." ...)
- on modern processors (at least from the 2000s) can handle far more then one string modification per cpu cycle. On top of that using through FOR ... ENDFOR and having to incrementally step from x = 0 to 31 takes additional 32 cpu cycles that slow us down even more.
- to still preserve some kind of readability all the STRTRAN() calls to manipulate the string are combined in 4 big inline executions. By tracking this function with "SET COVERAGE TO" this new code was executed about 8x faster than the original code.

*nfjsonperftest.prg*
- increased the default sample size from 10 to 75, because this gives us more accurate execution times for read & create. When i started testing some high & low execution times were off by 2-5 times. no idea how i should compare these results.
- for better results i needed even larger sample sizes, but everytime i changed the value in "nfjsonperftest.prg" i had to close VFP, delete the FXP and start it up again so the new values would be used. this pissed me off, so now you can see and change the sample size interactively in the form. 
- since i could now test with bigger sample sizes the results got far more consistent  and meaningful. Because larger sample sizes take longer to execute i needed some kind of indicator to see if a single execution is finished. So now the read & create informations are shown in red while execution is running.
- added one more json sample with special characters used in most of the strings.
- changed the size of the form, because it bothered me to scroll through the ~20 samples on my 27" display.

==============

Feel free to comment these changes or roast me (if necessary). I hope you all can somewhat understand my english, since i try my best to be clear.

P.S.: Lots of kudos to all the bigbrain creators and maintainers that made nfjson to what it is today. I know i have already learned a lot by digging through some parts of this code. ;-) 